### PR TITLE
:wrench: Include additional headers for draft-content.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -30,3 +30,5 @@ paths:
     response:
       headers:
         "X-Origin-System-Id": origin_system
+        "Write-Request-Id": draft_ref
+        "Last-Modified-RFC3339": last_modified


### PR DESCRIPTION
The draft-content-api requires the draft_ref and last_modified values so that they can be included in its payload to the mapper.
- `Write-Request-Id` returns the X-Request-Id value used in the corresponding PUT operation for the content.
- `Last-Modified-RFC3339` returns the last modified value. (There is an HTTP standard header `Last-Modified` but it uses RFC822 `date-time` format).