### PR TITLE
connection mgmt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ jobs:
           CIRCLE_COVERAGE_REPORT: /tmp/coverage-results
           DB_TEST_URL: root:password@/pac
       - image: mysql:5.6
+        # db.t2.small allows 45 connections
+        command: [mysqld, --max-connections=45]
         environment:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: pac

--- a/db/connection.go
+++ b/db/connection.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func Connect(dbUrl string) (*sql.DB, error) {
+func Connect(dbUrl string, maxConnections int) (*sql.DB, error) {
 	i := strings.Index(dbUrl, ":")
 	j := strings.Index(dbUrl, "@")
 	log.Infof("Connecting to %s:********@%s", dbUrl[:i], dbUrl[j+1:])
@@ -19,6 +19,9 @@ func Connect(dbUrl string) (*sql.DB, error) {
 		err = db.Ping() // force a meaningful connection check
 		// we may return a *sql.DB even when there seems to be a connection error - it might recover
 	}
+
+	log.Infof("Maximum DB connections = %v", maxConnections)
+	db.SetMaxOpenConns(maxConnections)
 
 	return db, err
 }

--- a/db/service_rw_test.go
+++ b/db/service_rw_test.go
@@ -63,7 +63,7 @@ func (s *ServiceRWTestSuite) SetupSuite() {
 	j := strings.Index(s.dbAdminUrl, "/")
 	dbUrl := fmt.Sprintf("%s:%s@%s/%s", pacUser, pacPassword, s.dbAdminUrl[i+1:j], pacSchema)
 
-	conn, err := Connect(dbUrl)
+	conn, err := Connect(dbUrl, 5)
 	require.NoError(s.T(), err)
 
 	cfg, err := config.ReadConfig("../config.yml")

--- a/db/service_rw_test.go
+++ b/db/service_rw_test.go
@@ -45,35 +45,37 @@ func TestServiceRWTestSuite(t *testing.T) {
 }
 
 func (s *ServiceRWTestSuite) SetupSuite() {
-	conn, err := sql.Open("mysql", s.dbAdminUrl)
+	adminConn, err := sql.Open("mysql", s.dbAdminUrl)
 	require.NoError(s.T(), err)
-	defer conn.Close()
+	defer adminConn.Close()
 
 	pacSchema := "pac_test"
 	pacUser := "pac_test_user"
 
-	err = cleanDatabase(conn, pacUser, pacSchema)
+	err = cleanDatabase(adminConn, pacUser, pacSchema)
 	require.NoError(s.T(), err)
 
 	pacPassword := uuid.NewV4().String()
-	err = createDatabase(conn, pacUser, pacPassword, pacSchema)
+	err = createDatabase(adminConn, pacUser, pacPassword, pacSchema)
 	require.NoError(s.T(), err)
 
 	i := strings.Index(s.dbAdminUrl, "@")
 	j := strings.Index(s.dbAdminUrl, "/")
 	dbUrl := fmt.Sprintf("%s:%s@%s/%s", pacUser, pacPassword, s.dbAdminUrl[i+1:j], pacSchema)
 
-	conn, err = Connect(dbUrl)
+	conn, err := Connect(dbUrl)
 	require.NoError(s.T(), err)
 
 	cfg, err := config.ReadConfig("../config.yml")
 	require.NoError(s.T(), err)
 
 	s.dbConn = conn
+	s.dbConn.SetMaxIdleConns(0)
 	s.service = NewService(conn, true, cfg)
 }
 
 func (s *ServiceRWTestSuite) TearDownSuite() {
+	assert.Equal(s.T(), 0, s.dbConn.Stats().OpenConnections, "open connections")
 	s.dbConn.Close()
 }
 

--- a/db/service_schema_test.go
+++ b/db/service_schema_test.go
@@ -51,7 +51,7 @@ func (s *ServiceSchemaTestSuite) SetupTest() {
 	j := strings.Index(s.dbAdminUrl, "/")
 	s.dbUrl = fmt.Sprintf("%s:%s@%s/%s", pacUser, pacPassword, s.dbAdminUrl[i+1:j], pacSchema)
 
-	conn, err = Connect(s.dbUrl)
+	conn, err = Connect(s.dbUrl, 5)
 	require.NoError(s.T(), err)
 	s.dbConn = conn
 }

--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ import (
 const (
 	systemCode     = "generic-rw-aurora"
 	appDescription = "Generic R/W for Aurora"
+	// db.t2.small allows a maximum of 45 connections, but there are likely 2 instances of this service
+	maxConnections = 20
 )
 
 func main() {
@@ -93,7 +95,7 @@ func main() {
 			log.WithError(err).Fatal("unable to read r/w YAML configuration")
 		}
 
-		conn, err := db.Connect(*dbURL)
+		conn, err := db.Connect(*dbURL, maxConnections)
 		if err != nil {
 			log.WithError(err).Error("unable to connect to database")
 		}

--- a/main.go
+++ b/main.go
@@ -21,8 +21,8 @@ import (
 const (
 	systemCode     = "generic-rw-aurora"
 	appDescription = "Generic R/W for Aurora"
-	// db.t2.small allows a maximum of 45 connections, but there are likely 2 instances of this service
-	maxConnections = 20
+	// db.t2.small allows a maximum of 45 connections, but there are likely 2 instances of this service in each of 2 regions
+	maxConnections = 10
 )
 
 func main() {


### PR DESCRIPTION
Prevent "Error 1040: Too many connections" when the service is under load by specifying the client can open a maximum of 10 connections. (The database is a db.t2.small which is configured by AWS to accept a maximum of 45 connections). This is a rather simplistic fix, as requests will in principle block forever awaiting a connection to become available, but it addresses the immediate problem.